### PR TITLE
Fix TTS port env expansion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ENV TTS_PORT=5002
 
 EXPOSE ${TTS_PORT}
 
-CMD ["tts-server", "--model_name", "${MODEL_NAME}", "--port", "${TTS_PORT}", "--use_cuda", "0", "--host", "0.0.0.0"]
+CMD ["/bin/sh", "-c", "tts-server --model_name \"$MODEL_NAME\" --port $TTS_PORT --use_cuda 0 --host 0.0.0.0"]


### PR DESCRIPTION
## Summary
- ensure the CMD resolves MODEL_NAME and TTS_PORT environment variables at runtime by invoking tts-server through /bin/sh

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccc7e8b82c832d92085a25e7010406