### PR TITLE
Remove unsupported host flag from tts-server command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ENV TTS_PORT=5002
 
 EXPOSE ${TTS_PORT}
 
-CMD ["/bin/sh", "-c", "tts-server --model_name \"$MODEL_NAME\" --port $TTS_PORT --use_cuda 0 --host 0.0.0.0"]
+CMD ["/bin/sh", "-c", "tts-server --model_name \"$MODEL_NAME\" --port $TTS_PORT --use_cuda 0"]

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ ENV TTS_PORT=5002
 
 EXPOSE ${TTS_PORT}
 
-CMD ["tts-server", "--model_name", "${MODEL_NAME}", "--port", "${TTS_PORT}", "--use_cuda", "0", "--host", "0.0.0.0"]
+CMD ["tts-server", "--model_name", "${MODEL_NAME}", "--port", "${TTS_PORT}", "--use_cuda", "0"]
 ```
 
 Create `docker-compose.yml`:


### PR DESCRIPTION
## Summary
- drop the unsupported `--host` parameter from the Docker CMD so the container starts cleanly
- update the README example to match the working server invocation

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ccc9bbc974832d8cd9645b8b52edba