### PR TITLE
Preseed Coqui TOS acceptance for xtts container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN pip install --no-cache-dir TTS==0.22.0
 
 ENV MODEL_NAME=tts_models/multilingual/multi-dataset/xtts_v2
 ENV TTS_PORT=5002
+ENV COQUI_TOS_AGREED=1
 
 EXPOSE ${TTS_PORT}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - MODEL_NAME=${MODEL_NAME:-tts_models/multilingual/multi-dataset/xtts_v2}
       - TTS_PORT=${TTS_PORT:-5002}
+      - COQUI_TOS_AGREED=${COQUI_TOS_AGREED:-1}
     volumes:
       - ./cache:/root/.local/share/tts
     networks:

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,7 @@ RUN pip install --no-cache-dir TTS==0.22.0
 
 ENV MODEL_NAME=tts_models/multilingual/multi-dataset/xtts_v2
 ENV TTS_PORT=5002
+ENV COQUI_TOS_AGREED=1
 
 EXPOSE ${TTS_PORT}
 
@@ -37,6 +38,7 @@ services:
     environment:
       - MODEL_NAME=${MODEL_NAME:-tts_models/multilingual/multi-dataset/xtts_v2}
       - TTS_PORT=${TTS_PORT:-5002}
+      - COQUI_TOS_AGREED=${COQUI_TOS_AGREED:-1}
     volumes:
       - ./cache:/root/.local/share/tts
     networks:
@@ -51,6 +53,8 @@ networks:
 ```
 
 First boot downloads the model into `./cache`, so keep that directory around for subsequent runs.
+
+Set `COQUI_TOS_AGREED=1` only if you have already reviewed and accepted the Coqui XTTS licensing terms referenced in the runtime prompt.  The environment variable simply pre-seeds the agreement file that the downloader looks for so the container can bootstrap non-interactively.
 
 ### 2. Launch xTTS
 


### PR DESCRIPTION
## Summary
- add COQUI_TOS_AGREED env var to Docker image and compose definition to bypass interactive prompt after accepting the license
- document the new environment variable in the README and clarify that it requires prior license acceptance

## Testing
- not run (infrastructure change only)


------
https://chatgpt.com/codex/tasks/task_e_68ccccac63a0832d8dfc3856e00a3eb9